### PR TITLE
Allows configuration of port for unit tests.

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -31,6 +31,7 @@
         <env name="DB_USER" value=""/>
         <env name="DB_PASS" value=""/>
         <env name="DB_HOST" value="localhost"/>
+        <env name="DB_PORT" value="3306"/>
         <env name="XDEBUG_MODE" value="coverage"/>
     </php>
     -->

--- a/tests/TestConfig.php
+++ b/tests/TestConfig.php
@@ -29,7 +29,7 @@ class TestConfig
                 getenv('DB_USER'),
                 getenv('DB_PASS'),
                 getenv('DB_HOST'),
-                3306
+                getenv('DB_PORT') ?: 3306,
             )
         );
         self::$db->setTablePrefix('t_');


### PR DESCRIPTION
- DB_PORT constant added to phpunit.xml.dist
- Use this constant or the default port 3306 in the TestConfig class.